### PR TITLE
Admin Information page

### DIFF
--- a/_resources/For Parents.md
+++ b/_resources/For Parents.md
@@ -11,10 +11,6 @@ variant: tiptap
 </p>
 </li>
 <li>
-<p><a href="/about-us/links/parents/admin-information" rel="noopener noreferrer nofollow" target="_blank">Admin Information</a>
-</p>
-</li>
-<li>
 <p><a href="/about-us/links/parents/financial-assistance" rel="noopener noreferrer nofollow" target="_blank">Financial&nbsp;Assistance</a>
 </p>
 </li>


### PR DESCRIPTION
Took away the link to Admin Information on the For Parents page. No longer directly accessible.